### PR TITLE
Update description

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Serverless service that generates dynamic Open Graph images that you can embed in your `<meta>` tags.
 
+For each keystroke, headless chromium is used to render an HTML page and take a screenshot of the result which gets cached.
+
 See the image embedded in the tweet for a real use case.
 
 

--- a/public/index.html
+++ b/public/index.html
@@ -27,6 +27,7 @@
             <div class="center">
                 <h2>What is this?</h2>
                 <p>This is a service that generates dynamic <a href="http://ogp.me">Open Graph</a> images that you can embed in your <code>&lt;meta&gt;</code> tags.</p>
+                <p>For each keystroke, headless chromium is used to render an HTML page and take a screenshot of the result which gets cached.</p>
                 <p>Find out how this works and deploy your own image generator by visiting <a href="https://github.com/zeit/og-image">GitHub</a>.</p>
                 <footer>Proudly hosted on <a href="https://zeit.co/now">▲ZEIT Now</a></footer>
             </div>


### PR DESCRIPTION
This adds the description "For each keystroke, headless chromium is used to render an HTML page and take a screenshot of the result which gets cached."