### PR TITLE
Remove dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Generate an open graph image for twitter/facebook/etc",
   "main": "dist/card.js",
   "scripts": {
-    "dev": "now dev",
     "build": "tsc",
     "now-build": "tsc",
     "watch": "tsc --watch"


### PR DESCRIPTION
Fixes #81

The `now-dev` script assumes a http server is running.

Since PR 673 landed, `dev` is assumed to be `now-dev` so we no longer need this script.

Related to https://github.com/zeit/now-builders/pull/673