### PR TITLE
Recursively glob static files

### DIFF
--- a/now.json
+++ b/now.json
@@ -5,7 +5,7 @@
     "regions": ["all"],
     "public": true,
     "builds": [
-        { "src": "public/*", "use": "@now/static" },
+        { "src": "public/**", "use": "@now/static" },
         { "src": "package.json", "use": "@now/static-build" },
         { "src": "src/card.ts", "use": "@now/node", "config": { "maxLambdaSize": "36mb" } }
     ],


### PR DESCRIPTION
We should use best practices here so that subdirectories are also published to static from the `public` directory such as `public/images/` and `public/css/` and so on.