### PR TITLE
Pin the node runtime to 8.10.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "Generate an open graph image for twitter/facebook/etc",
   "main": "dist/card.js",
+  "engines": {
+    "node": "8.10.x"
+  },
   "scripts": {
     "build": "tsc",
     "now-build": "tsc",


### PR DESCRIPTION
It seems that `chrome-aws-lambda` only works with Node 8