### PR TITLE
Move alias/version out of now.json, use account instead

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,7 +1,4 @@
 {
-    "name": "og-image",	 
-    "alias": [ "og-image.now.sh", "api-og-image.zeit.sh" ],
-    "version": 2,
     "regions": ["all"],
     "public": true,
     "routes": [


### PR DESCRIPTION
We no longer need to add this information in the `now.json`.

Instead, it can be configured using https://zeit.co/dashboard in the deployment's domains.