### PR TITLE
Remove mention of alias, no longer applicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You'll want to fork this repository and deploy your own image generator.
 4. Make changes by swapping out images, changing colors, etc (see [contributing](https://github.com/zeit/og-image/blob/master/CONTRIBUTING.md) for more info)
 5. Run locally with `now dev` and visit [localhost:3000](http://localhost:3000)  (if nothing happens, run `npm install -g now`)
 6. Deploy to the cloud by running `now` and you'll get a unique URL
-7. Setup [GitHub](https://zeit.co/github) to autodeply on push and set an `alias` in [now.json](https://zeit.co/docs/v2/advanced/configuration) to customize your URL.
+7. Setup [GitHub](https://zeit.co/github) to autodeply on push
 
 Alternatively, you can do a one-click to deploy with the button below.
 


### PR DESCRIPTION
This can be configured on zeit.co/dashboard under the deployment domains.