### PR TITLE
Add blue deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You'll want to fork this repository and deploy your own image generator.
 
 Alternatively, you can do a one-click to deploy with the button below.
 
-[![Deploy to now](https://deploy.now.sh/static/button.svg)](https://zeit.co/new/project?template=zeit/og-image)
+[![Deploy to now](https://zeit.co/button)](https://zeit.co/new/project?template=zeit/og-image)
 
 Once you have an image generator that sparks joy, you can setup [automatic Now + GitHub](https://zeit.co/github) deployments so that pushing to master is also deploying to production! 🚀
 


### PR DESCRIPTION
We resigned the deploy button to look like this: https://zeit.co/button