### PR TITLE
Change assets to vercel.com

### DIFF
--- a/api/_lib/parser.ts
+++ b/api/_lib/parser.ts
@@ -52,8 +52,8 @@ function getArray(stringOrArray: string[] | string | undefined): string[] {
 
 function getDefaultImages(images: string[], theme: Theme): string[] {
     const defaultImage = theme === 'light'
-        ? 'https://assets.vercel.com/image/upload/front/assets/design/zeit-black-triangle.svg'
-        : 'https://assets.vercel.com/image/upload/front/assets/design/zeit-white-triangle.svg';
+        ? 'https://assets.vercel.com/image/upload/front/assets/design/vercel-triangle-black.svg'
+        : 'https://assets.vercel.com/image/upload/front/assets/design/vercel-triangle-white.svg';
 
     if (!images || !images[0]) {
         return [defaultImage];

--- a/api/_lib/parser.ts
+++ b/api/_lib/parser.ts
@@ -40,8 +40,14 @@ export function parseRequest(req: IncomingMessage) {
     return parsedRequest;
 }
 
-function getArray(stringOrArray: string[] | string): string[] {
-    return Array.isArray(stringOrArray) ? stringOrArray : [stringOrArray];
+function getArray(stringOrArray: string[] | string | undefined): string[] {
+    if (typeof stringOrArray === 'undefined') {
+        return [];
+    } else if (Array.isArray(stringOrArray)) {
+        return stringOrArray;
+    } else {
+        return [stringOrArray];
+    }
 }
 
 function getDefaultImages(images: string[], theme: Theme): string[] {
@@ -49,7 +55,7 @@ function getDefaultImages(images: string[], theme: Theme): string[] {
         ? 'https://assets.vercel.com/image/upload/front/assets/design/zeit-black-triangle.svg'
         : 'https://assets.vercel.com/image/upload/front/assets/design/zeit-white-triangle.svg';
 
-    if (images.length === 0) {
+    if (!images || !images[0]) {
         return [defaultImage];
     }
     if (!images[0].startsWith('https://assets.vercel.com/') && !images[0].startsWith('https://assets.zeit.co/')) {

--- a/api/_lib/parser.ts
+++ b/api/_lib/parser.ts
@@ -45,10 +45,15 @@ function getArray(stringOrArray: string[] | string): string[] {
 }
 
 function getDefaultImages(images: string[], theme: Theme): string[] {
-    if (images.length > 0 && images[0] && images[0].startsWith('https://assets.zeit.co/image/upload/front/assets/design/')) {
-        return images;
+    const defaultImage = theme === 'light'
+        ? 'https://assets.vercel.com/image/upload/front/assets/design/zeit-black-triangle.svg'
+        : 'https://assets.vercel.com/image/upload/front/assets/design/zeit-white-triangle.svg';
+
+    if (images.length === 0) {
+        return [defaultImage];
     }
-    return theme === 'light'
-    ? ['https://assets.zeit.co/image/upload/front/assets/design/zeit-black-triangle.svg']
-    : ['https://assets.zeit.co/image/upload/front/assets/design/zeit-white-triangle.svg'];
+    if (!images[0].startsWith('https://assets.vercel.com/') && !images[0].startsWith('https://assets.zeit.co/')) {
+        images[0] = defaultImage;
+    }
+    return images;
 }

--- a/web/index.ts
+++ b/web/index.ts
@@ -142,14 +142,14 @@ const markdownOptions: DropdownOption[] = [
 ];
 
 const imageLightOptions: DropdownOption[] = [
-    { text: 'Vercel', value: 'https://assets.vercel.com/image/upload/front/assets/design/zeit-black-triangle.svg' },
+    { text: 'Vercel', value: 'https://assets.vercel.com/image/upload/front/assets/design/vercel-triangle-black.svg' },
     { text: 'Next.js', value: 'https://assets.vercel.com/image/upload/front/assets/design/nextjs-black-logo.svg' },
     { text: 'Hyper', value: 'https://assets.vercel.com/image/upload/front/assets/design/hyper-color-logo.svg' },
 ];
 
 const imageDarkOptions: DropdownOption[] = [
 
-    { text: 'Vercel', value: 'https://assets.vercel.com/image/upload/front/assets/design/zeit-white-triangle.svg' },
+    { text: 'Vercel', value: 'https://assets.vercel.com/image/upload/front/assets/design/vercel-triangle-white.svg' },
     { text: 'Next.js', value: 'https://assets.vercel.com/image/upload/front/assets/design/nextjs-white-logo.svg' },
     { text: 'Hyper', value: 'https://assets.vercel.com/image/upload/front/assets/design/hyper-bw-logo.svg' },
 ];

--- a/web/index.ts
+++ b/web/index.ts
@@ -142,16 +142,16 @@ const markdownOptions: DropdownOption[] = [
 ];
 
 const imageLightOptions: DropdownOption[] = [
-    { text: 'Vercel', value: 'https://assets.zeit.co/image/upload/front/assets/design/zeit-black-triangle.svg' },
-    { text: 'Next.js', value: 'https://assets.zeit.co/image/upload/front/assets/design/nextjs-black-logo.svg' },
-    { text: 'Hyper', value: 'https://assets.zeit.co/image/upload/front/assets/design/hyper-color-logo.svg' },
+    { text: 'Vercel', value: 'https://assets.vercel.com/image/upload/front/assets/design/zeit-black-triangle.svg' },
+    { text: 'Next.js', value: 'https://assets.vercel.com/image/upload/front/assets/design/nextjs-black-logo.svg' },
+    { text: 'Hyper', value: 'https://assets.vercel.com/image/upload/front/assets/design/hyper-color-logo.svg' },
 ];
 
 const imageDarkOptions: DropdownOption[] = [
 
-    { text: 'Vercel', value: 'https://assets.zeit.co/image/upload/front/assets/design/zeit-white-triangle.svg' },
-    { text: 'Next.js', value: 'https://assets.zeit.co/image/upload/front/assets/design/nextjs-white-logo.svg' },
-    { text: 'Hyper', value: 'https://assets.zeit.co/image/upload/front/assets/design/hyper-bw-logo.svg' },
+    { text: 'Vercel', value: 'https://assets.vercel.com/image/upload/front/assets/design/zeit-white-triangle.svg' },
+    { text: 'Next.js', value: 'https://assets.vercel.com/image/upload/front/assets/design/nextjs-white-logo.svg' },
+    { text: 'Hyper', value: 'https://assets.vercel.com/image/upload/front/assets/design/hyper-bw-logo.svg' },
 ];
 
 const widthOptions = [


### PR DESCRIPTION
We need to support both `assets.vercel.com` as well as `assets.zeit.co` for backwards compatibility, but we'll change the default to `assets.vercel.com`.